### PR TITLE
Change check_model and file writing order.

### DIFF
--- a/src/onnxmodel_utils/model.py
+++ b/src/onnxmodel_utils/model.py
@@ -1279,11 +1279,14 @@ class Model(Base):
 
     def save(self, path: str):
         try:
-            onnx.checker.check_model(self.to_onnx_model(), full_check=True)
+            with open(path, "wb") as f:
+                f.write(self.to_onnx_model().SerializeToString())
+            onnx.checker.check_model(path, full_check=True)
         except:
             logger.exception("Model is not valid")
-        with open(path, "wb") as f:
-            f.write(self.to_onnx_model().SerializeToString())
+            if os.path.isfile(path):
+                os.remove(path)
+
 
     @classmethod
     def load(cls, path: str):


### PR DESCRIPTION
A call to `check_model` gives an error if a protobuf object greater than 2GB is passed in. 
However, if a[ path to the model file is passed in, the call succeeds](https://github.com/onnx/onnx/issues/3275#issuecomment-1128042821). 
I changed the code in `save()` to use the model path. Because the file doesn't yet exist at the time of the call to `check_model` I also reversed the order of file writing and model checking.
If for any reason an exception is thrown, I delete the file thus created as it is not likely to be valid.