### PR TITLE
Support for ONNX mdoels with external tensors

### DIFF
--- a/src/onnxmodel_utils/utils.py
+++ b/src/onnxmodel_utils/utils.py
@@ -112,7 +112,8 @@ def build_if_model(
         tensor_list,
     )
     ir_version = max(then_model.ir_version, else_model.ir_version, 8)
-    model = Model(graph, ir_version)
+    use_ext_tensors = then_model.use_ext_tensors or else_model.use_ext_tensors
+    model = Model(graph, ir_version, use_ext_tensors=use_ext_tensors)
     for opset in then_model.opset_imports:
         model.add_opset(opset.domain, opset.version)
     for opset in else_model.opset_imports:
@@ -191,7 +192,8 @@ def build_if_model_with_cache(
         tensor_list,
     )
     ir_version = max(cache_model.ir_version, cacheless_model.ir_version, 8)
-    model = Model(graph, ir_version)
+    use_ext_tensors = cache_model.use_ext_tensors or cacheless_model.use_ext_tensors
+    model = Model(graph, ir_version, use_ext_tensors=use_ext_tensors)
     for opset in cache_model.opset_imports:
         model.add_opset(opset.domain, opset.version)
     for opset in cacheless_model.opset_imports:


### PR DESCRIPTION
This Pull Request enables Model class to handle ONNX models that use external files to store tensor data. In particular, it enables using models that exceed 2GB in size.

### Key Changes:

 * Introduction of `use_ext_tensors` parameter: 
   Several functions now include a `use_ext_tensors` parameter. This new parameter dictates whether the model should operate with tensor data stored externally.

 * Setting the `base_dir` parameter: 
   To ensure the ONNX library can accurately locate the external tensor files, the base_dir parameter has been set in the `numpy_helper.to_array()` function. This necessitated adding a base_path parameter to several related functions.
   
 * New `save_onnx_model()` function: 
   Calls to `onnx.save()` are wrapped in a new function `save_onnx_model()`. This function is responsible for 
   * enabling use of external tensors, 
   * setting the `ext_tensor_filename` parameter (when provided)
   * removing any previous versions of the tensor file. 
     * By removing outdated data, this ensures that the md5 digest calculation in the `td` module works as expected. 

